### PR TITLE
Work around #384

### DIFF
--- a/proplot/figure.py
+++ b/proplot/figure.py
@@ -1193,6 +1193,8 @@ class Figure(mfigure.Figure):
             axs = ax._get_span_axes(pos, panels=False)  # returns panel or main axes
             if any(getattr(ax, '_share' + x) for ax in axs):
                 continue  # nothing to align or axes have parents
+            _ref_label_text = getattr(ax, x + 'axis').label.get_text()
+            axs = list(_ax for _ax in axs if getattr(_ax, x + 'axis').label.get_text() == _ref_label_text)
             seen.update(axs)
             if span or align:
                 if hasattr(self, '_align_label_groups'):


### PR DESCRIPTION
The issue is, for complex layouts such as the one below, `proplot` screws up shared axes labels positions.
```raw
   1111111
L  1111111
A
B  1111111
E  1111111
L
1  222 222
   222 222
   222 222
```
In the above case, `LABEL1` occupies the entire column even though the second group of plots might have its own shared and different label axis. The patch addresses this case and checks whether label text is the same across subject axes.

Further work is needed in this direction to develop a definitive policy regarding axes label grouping.