### PR TITLE
fix: dont check bool dtype until after ndarray conversion

### DIFF
--- a/proplot/internals/inputs.py
+++ b/proplot/internals/inputs.py
@@ -130,15 +130,16 @@ def _to_numpy_array(data, strip_units=False):
         data = data.data  # support pint quantities that get unit-stripped later
     elif isinstance(data, (DataFrame, Series, Index)):
         data = data.values
-    if data.dtype == bool:
-        data = data.view(np.uint8)
     if Quantity is not ndarray and isinstance(data, Quantity):
         if strip_units:
             return np.atleast_1d(data.magnitude)
         else:
             return np.atleast_1d(data.magnitude) * data.units
     else:
-        return np.atleast_1d(data)  # natively preserves masked arrays
+        d = np.atleast_1d(data)  # natively preserves masked arrays
+        if d.dtype == bool:
+            d = d.view(np.uint8)
+        return d
 
 
 def _to_masked_array(data, *, copy=False):

--- a/proplot/tests/test_axes.py
+++ b/proplot/tests/test_axes.py
@@ -1,0 +1,14 @@
+import pytest
+
+import numpy as np
+import proplot as pplt
+
+
+def test_axes_plot():
+    """Test axes plots work with lists or arrays"""
+    x = np.arange(10)
+    fig, ax = pplt.subplots()
+    ax.plot(x)
+    ax.plot(x, x)
+
+    ax.plot([1, 2, 3], [4, 5, 6])


### PR DESCRIPTION
This appears to fix #411


```ipython
In [1]: import proplot as pplt
import numpy as np

In [2]: import numpy as np

In [3]: fig, ax = pplt.subplot()
   ...: ax.plot(np.arange(10))
Out[3]: <a list of 1 Line2D objects>

```
@syrte Feel free to check on this if you have other
