### PR TITLE
Fixed an incompatibility issue with higher versions of matplotlib（3.8.2）

### DIFF
--- a/proplot/colors.py
+++ b/proplot/colors.py
@@ -2758,7 +2758,14 @@ def _init_cmap_database():
     """
     # WARNING: Skip over the matplotlib native duplicate entries
     # with suffixes '_r' and '_shifted'.
-    attr = '_cmap_registry' if hasattr(mcm, '_cmap_registry') else 'cmap_d'
+
+    if hasattr(mcm, '_cmap_registry'):
+        attr = '_cmap_registry'
+    else:
+        if hasattr(mcm, 'cmap_d'):
+            attr='cmap_d'
+        else:
+            attr = '_colormaps'
     database = getattr(mcm, attr)
     if mcm.get_cmap is not _get_cmap:
         mcm.get_cmap = _get_cmap

--- a/proplot/figure.py
+++ b/proplot/figure.py
@@ -7,6 +7,7 @@ import inspect
 import os
 from numbers import Integral
 
+import matplotlib
 import matplotlib.axes as maxes
 import matplotlib.figure as mfigure
 import matplotlib.gridspec as mgridspec
@@ -888,12 +889,13 @@ class Figure(mfigure.Figure):
         """
         Get a renderer at all costs. See matplotlib's tight_layout.py.
         """
-        if self._cachedRenderer:
-            renderer = self._cachedRenderer
+        canvas = self.canvas
+        if canvas and hasattr(canvas, 'get_renderer'):
+            renderer = canvas.get_renderer()
         else:
-            canvas = self.canvas
-            if canvas and hasattr(canvas, 'get_renderer'):
-                renderer = canvas.get_renderer()
+            if(matplotlib.__version__>='3.6'):
+                from matplotlib import backend_bases
+                renderer = backend_bases._get_renderer(self)
             else:
                 from matplotlib.backends.backend_agg import FigureCanvasAgg
                 canvas = FigureCanvasAgg(self)

--- a/proplot/internals/rcsetup.py
+++ b/proplot/internals/rcsetup.py
@@ -10,11 +10,15 @@ from numbers import Integral, Real
 import matplotlib.rcsetup as msetup
 import numpy as np
 from cycler import Cycler
+import matplotlib
 from matplotlib import RcParams
 from matplotlib import rcParamsDefault as _rc_matplotlib_native
 from matplotlib.colors import Colormap
 from matplotlib.font_manager import font_scalings
-from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
+if(hasattr(matplotlib,'fontconfig_pattern')):
+    from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
+else:
+    from matplotlib._fontconfig_pattern import parse_fontconfig_pattern
 
 from . import ic  # noqa: F401
 from . import warnings
@@ -44,8 +48,8 @@ VALIDATE_REGISTERED_COLORS = False
 BLACK = 'black'
 CYCLE = 'colorblind'
 CMAPCYC = 'twilight'
-CMAPDIV = 'BuRd'
-CMAPSEQ = 'Fire'
+CMAPDIV = 'BuPu'
+CMAPSEQ = 'magma'
 CMAPCAT = 'colorblind10'
 DIVERGING = 'div'
 FRAMEALPHA = 0.8  # legend and colorbar

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 [options]
 packages = proplot
 install_requires =
-    matplotlib>=3.0.0,<3.6.0
+    matplotlib>=3.0.0,<3.8.3
     numpy
 include_package_data = True
 python_requires = >=3.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 [options]
 packages = proplot
 install_requires =
-    matplotlib>=3.0.0,<3.8.3
+    matplotlib>=3.0.0,<=3.8.2
     numpy
 include_package_data = True
 python_requires = >=3.6.0


### PR DESCRIPTION
Referenced to previous commits that attempted to fix compatibility with higher versions of matplotlib.

On the premise of ensuring that matplotlib versions below 3.6 continue to run, we will do our best to achieve compatibility with higher versions of matplotlib （3.8.2）.

The code is tested and runs normally under matplotlib 3.8.2 version (ubuntu).